### PR TITLE
`fail-build` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,36 @@ jobs:
 | Name                  | Description                           | Required | Default |
 | --------------------- | ------------------------------------- | -------- | ------- |
 | `language`            | Programming language to check for EOL | Yes      |         |
+| `fail-build`          | Set `true` to fail build when EOL check fails | No | false |
 | `slack-webhook-url`   | Webhook URL for Slack                 | No       |         |
 | `discord-webhook-url` | Webhook URL for Discord               | No       |         |
 | `teams-webhook-url`   | Webhook URL for Microsoft Teams       | No       |         |
 
-## Example
+## Examples
 
 ```yaml
-name: EOL Alert
+name: EOL Alert on Build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  eol-alert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run EOL Alert
+        uses: insectkorea/eol-alert@v1
+        with:
+          language: 'node'
+          fail-build: true
+```
+
+```yaml
+name: Scheduled EOL Alert
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -12,60 +12,24 @@ EOL Alert is a GitHub Action that alerts you about the End-of-Life (EOL) of majo
 
 ## Supported Languages
 
-- Go (go)
-- Node.js (nodejs)
-- Python (python)
-- Ruby (ruby)
-- Rust (rust)
+- Go (`golang`)
+- Node.js (`node`)
+- Python (`python`)
+- Ruby (`ruby`)
+- Rust (`rust`)
 
-## Supported Channels
+## Supported Alert Channels
 
 - Slack
 - Discord
 - Microsoft Teams
 
 ## Usage
+To use this action, create a workflow file (e.g., `.github/workflows/eol-alert.yml`) in your GitHub repository like the examples below.
 
-To use this action, create a workflow file (e.g., `.github/workflows/eol-alert.yml`) in your GitHub repository with the following content:
-
+### EOL Check on Build
 ```yaml
-name: EOL Alert
-
-on:
-  schedule:
-    - cron: '0 0 * * *' # Runs daily at midnight
-  workflow_dispatch:
-
-jobs:
-  eol-alert:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Run EOL Alert
-        uses: insectkorea/eol-alert@v1
-        with:
-          language: 'golang'
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          discord-webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
-```
-
-## Inputs
-
-| Name                  | Description                           | Required | Default |
-| --------------------- | ------------------------------------- | -------- | ------- |
-| `language`            | Programming language to check for EOL | Yes      |         |
-| `fail-build`          | Set `true` to fail build when EOL check fails | No | false |
-| `slack-webhook-url`   | Webhook URL for Slack                 | No       |         |
-| `discord-webhook-url` | Webhook URL for Discord               | No       |         |
-| `teams-webhook-url`   | Webhook URL for Microsoft Teams       | No       |         |
-
-## Examples
-
-```yaml
-name: EOL Alert on Build
+name: EOL Check on Build
 
 on:
   push:
@@ -81,10 +45,11 @@ jobs:
       - name: Run EOL Alert
         uses: insectkorea/eol-alert@v1
         with:
-          language: 'node'
+          language: node
           fail-build: true
 ```
 
+### Scheduled EOL Alert
 ```yaml
 name: Scheduled EOL Alert
 
@@ -103,12 +68,22 @@ jobs:
       - name: Run EOL Alert
         uses: insectkorea/eol-alert@v1
         with:
-          language: 'node'
+          language: node
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           discord-webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
           google-chat-webhook-url: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
 ```
+
+## Inputs
+
+| Name                  | Description                           | Required | Default |
+| --------------------- | ------------------------------------- | -------- | ------- |
+| `language`            | Programming language to check for EOL | Yes      |         |
+| `fail-build`          | Set `true` to fail build when EOL check fails | No | false |
+| `slack-webhook-url`   | Webhook URL for Slack                 | No       |         |
+| `discord-webhook-url` | Webhook URL for Discord               | No       |         |
+| `teams-webhook-url`   | Webhook URL for Microsoft Teams       | No       |         |
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   language:
     description: 'Programming language to check EOL for (e.g., golang, node)'
     required: true
+  fail-build:
+    description: "Set 'true' to fail build when EOL check fails"
+    required: false
+    default: 'false'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -33147,19 +33147,21 @@ async function checkEOLVersions(repoName) {
     throw new Error(`Unsupported language: ${languageInput}`);
   }
   const webhookUrls = getWebhookUrls();
+  const failBuild = getFailBuild();
   const languageHandler = LanguageFactory.create(language);
   const currentVersion = await languageHandler.getVersion();
   const endOfLifeApiUrl = `https://endoflife.date/api/${language}.json`;
-  if (Object.keys(webhookUrls).length === 0) {
+  if (!failBuild && Object.keys(webhookUrls).length === 0) {
     throw new Error("At least one webhook URL must be provided");
   }
+  let currentVersionInfo;
   try {
     const response = await axios_default.get(endOfLifeApiUrl);
     if (response.data.length === 0) {
       console.log("No versions found");
       return;
     }
-    const currentVersionInfo = response.data.find(
+    currentVersionInfo = response.data.find(
       (v) => v.cycle === currentVersion
     );
     const latestVersionInfo = response.data[0];
@@ -33181,7 +33183,14 @@ async function checkEOLVersions(repoName) {
     await sendAlerts(webhookUrls, message);
   } catch (error) {
     console.error("Error fetching versions or sending alert:", error);
+    return;
   }
+  const eol = isEOL(currentVersionInfo);
+  const statusMsg = "End of life check " + (eol ? "FAILED" : "ok");
+  if (eol && failBuild) {
+    throw new Error(statusMsg);
+  }
+  console.log(statusMsg);
 }
 function createAlertMessage(currentVersionInfo, latestVersionInfo, language, repoName) {
   (0, import_assert.default)(typeof currentVersionInfo.eol === "string", "EOL must be a string");
@@ -33205,6 +33214,12 @@ function createAlertMessage(currentVersionInfo, latestVersionInfo, language, rep
   :arrow_forward: Latest release: ${currentVersionInfo.latest} on ${currentVersionInfo.latestReleaseDate}.
   :arrow_forward: Latest release of latest version: ${latestVersionInfo.latest} on ${latestVersionInfo.latestReleaseDate}.`;
   }
+}
+function isEOL(versionInfo) {
+  (0, import_assert.default)(typeof versionInfo.eol === "string", "EOL must be a string");
+  const eolDate = new Date(versionInfo.eol);
+  const today = /* @__PURE__ */ new Date();
+  return eolDate < today;
 }
 async function sendAlerts(webhookUrls, message) {
   for (const [channel, webhookUrl] of Object.entries(webhookUrls)) {
@@ -33231,6 +33246,9 @@ function getWebhookUrls() {
   }
   return webhookUrls;
 }
+function getFailBuild() {
+  return core.getInput("fail-build").toLowerCase() === "true";
+}
 function getRepositoryName() {
   const githubRepository = process.env.GITHUB_REPOSITORY;
   if (!githubRepository) {
@@ -33251,6 +33269,7 @@ async function run() {
     if (error instanceof Error) {
       core2.setFailed(error.message);
     } else {
+      console.error(error);
       core2.setFailed("An unknown error occurred");
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ async function run() {
     if (error instanceof Error) {
       core.setFailed(error.message);
     } else {
+      console.error(error);
       core.setFailed("An unknown error occurred");
     }
   }

--- a/src/lib/__test__/eolAlert.test.ts
+++ b/src/lib/__test__/eolAlert.test.ts
@@ -105,7 +105,7 @@ describe("checkEOLVersions", () => {
         text: expect.stringContaining(`will reach EOL on ${futureEOLDate}`),
       },
     );
-    expect(console.log).toHaveBeenCalledWith("End of life check ok");
+    expect(console.log).toHaveBeenCalledWith("End of life check for golang ok");
   });
 
   it("should handle when the current version is not found in the EOL data", async () => {
@@ -137,21 +137,6 @@ describe("checkEOLVersions", () => {
     expect(mockedAxios.post).not.toHaveBeenCalled();
     expect(console.log).toHaveBeenCalledWith(
       "Current version 1.13 not found in the EOL data.",
-    );
-  });
-
-  it("should throw an error if no webhook URLs are provided", async () => {
-    mockedCore.getInput.mockImplementation((name: string) => {
-      switch (name) {
-        case "language":
-          return "golang";
-        default:
-          return "";
-      }
-    });
-
-    await expect(checkEOLVersions(repoName)).rejects.toThrow(
-      "At least one webhook URL must be provided",
     );
   });
 
@@ -188,7 +173,7 @@ describe("fail-build", () => {
     mockedAxios.get.mockResolvedValue(fixtureAxiosEOLResp);
 
     await expect(checkEOLVersions(repoName)).rejects.toThrow(
-      "End of life check FAILED",
+      "End of life check for golang FAILED",
     );
   });
 
@@ -211,7 +196,9 @@ describe("fail-build", () => {
 
     await checkEOLVersions(repoName);
 
-    expect(console.log).toHaveBeenCalledWith("End of life check FAILED");
+    expect(console.log).toHaveBeenCalledWith(
+      `End of life check for golang FAILED, EOL date was ${fixtureAxiosEOLResp.data[0].eol}`,
+    );
   });
 
   it("succeeds when EOL and fail-build unset", async () => {
@@ -231,7 +218,9 @@ describe("fail-build", () => {
 
     await checkEOLVersions(repoName);
 
-    expect(console.log).toHaveBeenCalledWith("End of life check FAILED");
+    expect(console.log).toHaveBeenCalledWith(
+      `End of life check for golang FAILED, EOL date was ${fixtureAxiosEOLResp.data[0].eol}`,
+    );
   });
 });
 

--- a/src/lib/__test__/eolAlert.test.ts
+++ b/src/lib/__test__/eolAlert.test.ts
@@ -19,6 +19,21 @@ const mockedCore = jest.mocked(core);
 const mockedFs = jest.mocked(fs);
 const repoName = "test-repo";
 
+const fixtureAxiosEOLResp = {
+  data: [
+    {
+      cycle: "1.15",
+      eol: "2023-02-06",
+      latest: "1.15.14",
+      latestReleaseDate: "2023-02-06",
+    },
+  ],
+};
+
+const futureEOLDate = formatDate(
+  new Date(new Date().getTime() + 90 * 24 * 60 * 60 * 1000),
+);
+
 describe("checkEOLVersions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -75,7 +90,7 @@ describe("checkEOLVersions", () => {
       data: [
         {
           cycle: "1.14",
-          eol: "2025-02-06",
+          eol: futureEOLDate,
           latest: "1.14.14",
           latestReleaseDate: "2023-02-06",
         },
@@ -87,9 +102,10 @@ describe("checkEOLVersions", () => {
     expect(mockedAxios.post).toHaveBeenCalledWith(
       "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
       {
-        text: expect.stringContaining("will reach EOL on 2025-02-06."),
+        text: expect.stringContaining(`will reach EOL on ${futureEOLDate}`),
       },
     );
+    expect(console.log).toHaveBeenCalledWith("End of life check ok");
   });
 
   it("should handle when the current version is not found in the EOL data", async () => {
@@ -109,7 +125,7 @@ describe("checkEOLVersions", () => {
       data: [
         {
           cycle: "1.14",
-          eol: "2025-02-06",
+          eol: futureEOLDate,
           latest: "1.14.14",
           latestReleaseDate: "2023-02-06",
         },
@@ -154,3 +170,71 @@ describe("checkEOLVersions", () => {
     );
   });
 });
+
+describe("fail-build", () => {
+  it("should throw an error when EOL and fail-build=true", async () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      switch (name) {
+        case "language":
+          return "golang";
+        case "fail-build":
+          return "true";
+        default:
+          return "";
+      }
+    });
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue("module example.com\n\ngo 1.15");
+    mockedAxios.get.mockResolvedValue(fixtureAxiosEOLResp);
+
+    await expect(checkEOLVersions(repoName)).rejects.toThrow(
+      "End of life check FAILED",
+    );
+  });
+
+  it("succeeds when EOL and fail-build=false", async () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      switch (name) {
+        case "language":
+          return "golang";
+        case "slack-webhook-url":
+          return "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX";
+        case "fail-build":
+          return "false";
+        default:
+          return "";
+      }
+    });
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue("module example.com\n\ngo 1.15");
+    mockedAxios.get.mockResolvedValue(fixtureAxiosEOLResp);
+
+    await checkEOLVersions(repoName);
+
+    expect(console.log).toHaveBeenCalledWith("End of life check FAILED");
+  });
+
+  it("succeeds when EOL and fail-build unset", async () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      switch (name) {
+        case "language":
+          return "golang";
+        case "slack-webhook-url":
+          return "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX";
+        default:
+          return "";
+      }
+    });
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue("module example.com\n\ngo 1.15");
+    mockedAxios.get.mockResolvedValue(fixtureAxiosEOLResp);
+
+    await checkEOLVersions(repoName);
+
+    expect(console.log).toHaveBeenCalledWith("End of life check FAILED");
+  });
+});
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}

--- a/src/lib/eolAlert.ts
+++ b/src/lib/eolAlert.ts
@@ -125,6 +125,7 @@ function createAlertMessage(
  * Check if version is EOL
  * @param versionInfo
  * @returns boolean
+ * @throws RangeError Invalid EOL date
  */
 function isEOL(versionInfo: VersionInfo): boolean {
   assert(typeof versionInfo.eol === "string", "EOL must be a string");

--- a/src/lib/eolAlert.ts
+++ b/src/lib/eolAlert.ts
@@ -99,6 +99,10 @@ function createAlertMessage(
 ): string {
   assert(typeof currentVersionInfo.eol === "string", "EOL must be a string");
   const eolDate = new Date(currentVersionInfo.eol);
+  assert(
+    !Number.isNaN(eolDate.getTime()),
+    `EOL is an invalid date: "${currentVersion.eol}"`,
+  );
   const today = new Date();
   const daysUntilEOL = Math.ceil(
     (eolDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
@@ -130,6 +134,10 @@ function createAlertMessage(
 function isEOL(versionInfo: VersionInfo): boolean {
   assert(typeof versionInfo.eol === "string", "EOL must be a string");
   const eolDate = new Date(versionInfo.eol);
+  assert(
+    !Number.isNaN(eolDate.getTime()),
+    `EOL is an invalid date: "${version.eol}"`,
+  );
   const today = new Date();
   return eolDate < today;
 }

--- a/src/lib/eolAlert.ts
+++ b/src/lib/eolAlert.ts
@@ -26,12 +26,9 @@ export async function checkEOLVersions(repoName: string) {
 
   const languageHandler = LanguageFactory.create(language);
   const currentVersion = await languageHandler.getVersion();
+  console.log(`Found ${language} version: ${currentVersion}`);
 
   const endOfLifeApiUrl = `https://endoflife.date/api/${language}.json`;
-
-  if (!failBuild && Object.keys(webhookUrls).length === 0) {
-    throw new Error("At least one webhook URL must be provided");
-  }
 
   let currentVersionInfo: VersionInfo;
 
@@ -75,10 +72,16 @@ export async function checkEOLVersions(repoName: string) {
   }
 
   const eol = isEOL(currentVersionInfo);
-  const statusMsg = "End of life check " + (eol ? "FAILED" : "ok");
-  if (eol && failBuild) {
-    // Fail build action.
-    throw new Error(statusMsg);
+  let statusMsg: string;
+  if (eol) {
+    statusMsg = `End of life check for ${language} FAILED, EOL date was ${currentVersionInfo.eol}`;
+    core.notice(statusMsg);
+    if (failBuild) {
+      // Fail build action.
+      throw new Error(statusMsg);
+    }
+  } else {
+    statusMsg = `End of life check for ${language} ok`;
   }
   console.log(statusMsg);
 }

--- a/src/lib/eolAlert.ts
+++ b/src/lib/eolAlert.ts
@@ -90,6 +90,7 @@ export async function checkEOLVersions(repoName: string) {
  * Create an alert message based on the current version's EOL status
  * @param currentVersionInfo - Information about the current version
  * @returns Alert message string
+ * @throws RangeError Invalid EOL date
  */
 function createAlertMessage(
   currentVersionInfo: VersionInfo,
@@ -101,7 +102,7 @@ function createAlertMessage(
   const eolDate = new Date(currentVersionInfo.eol);
   assert(
     !Number.isNaN(eolDate.getTime()),
-    `EOL is an invalid date: "${currentVersion.eol}"`,
+    `EOL is an invalid date: "${currentVersionInfo.eol}"`,
   );
   const today = new Date();
   const daysUntilEOL = Math.ceil(
@@ -136,7 +137,7 @@ function isEOL(versionInfo: VersionInfo): boolean {
   const eolDate = new Date(versionInfo.eol);
   assert(
     !Number.isNaN(eolDate.getTime()),
-    `EOL is an invalid date: "${version.eol}"`,
+    `EOL is an invalid date: "${versionInfo.eol}"`,
   );
   const today = new Date();
   return eolDate < today;

--- a/src/lib/eolAlert.ts
+++ b/src/lib/eolAlert.ts
@@ -67,7 +67,7 @@ export async function checkEOLVersions(repoName: string) {
     );
     await sendAlerts(webhookUrls, message);
   } catch (error) {
-    console.error("Error fetching versions or sending alert:", error);
+    core.error(`Error fetching versions or sending alert: ${error}`);
     return;
   }
 
@@ -75,7 +75,7 @@ export async function checkEOLVersions(repoName: string) {
   let statusMsg: string;
   if (eol) {
     statusMsg = `End of life check for ${language} FAILED, EOL date was ${currentVersionInfo.eol}`;
-    core.notice(statusMsg);
+    core.warning(statusMsg);
     if (failBuild) {
       // Fail build action.
       throw new Error(statusMsg);

--- a/src/lib/eolAlert.ts
+++ b/src/lib/eolAlert.ts
@@ -22,15 +22,19 @@ export async function checkEOLVersions(repoName: string) {
   }
 
   const webhookUrls = getWebhookUrls();
+  const failBuild = getFailBuild();
 
   const languageHandler = LanguageFactory.create(language);
   const currentVersion = await languageHandler.getVersion();
 
   const endOfLifeApiUrl = `https://endoflife.date/api/${language}.json`;
 
-  if (Object.keys(webhookUrls).length === 0) {
+  if (!failBuild && Object.keys(webhookUrls).length === 0) {
     throw new Error("At least one webhook URL must be provided");
   }
+
+  let currentVersionInfo: VersionInfo;
+
   try {
     const response = (await axios.get(endOfLifeApiUrl)) as {
       data: EOLResponse;
@@ -41,9 +45,9 @@ export async function checkEOLVersions(repoName: string) {
       return;
     }
 
-    const currentVersionInfo = response.data.find(
+    currentVersionInfo = response.data.find(
       (v: VersionInfo) => v.cycle === currentVersion,
-    );
+    ) as VersionInfo;
 
     const latestVersionInfo = response.data[0];
 
@@ -67,7 +71,16 @@ export async function checkEOLVersions(repoName: string) {
     await sendAlerts(webhookUrls, message);
   } catch (error) {
     console.error("Error fetching versions or sending alert:", error);
+    return;
   }
+
+  const eol = isEOL(currentVersionInfo);
+  const statusMsg = "End of life check " + (eol ? "FAILED" : "ok");
+  if (eol && failBuild) {
+    // Fail build action.
+    throw new Error(statusMsg);
+  }
+  console.log(statusMsg);
 }
 
 /**
@@ -103,6 +116,18 @@ function createAlertMessage(
   :arrow_forward: Latest release: ${currentVersionInfo.latest} on ${currentVersionInfo.latestReleaseDate}.
   :arrow_forward: Latest release of latest version: ${latestVersionInfo.latest} on ${latestVersionInfo.latestReleaseDate}.`;
   }
+}
+
+/**
+ * Check if version is EOL
+ * @param versionInfo
+ * @returns boolean
+ */
+function isEOL(versionInfo: VersionInfo): boolean {
+  assert(typeof versionInfo.eol === "string", "EOL must be a string");
+  const eolDate = new Date(versionInfo.eol);
+  const today = new Date();
+  return eolDate < today;
 }
 
 /**
@@ -146,6 +171,14 @@ function getWebhookUrls(): { [channel: string]: string } {
   }
 
   return webhookUrls;
+}
+
+/**
+ * Get fail-build flag
+ * @returns Boolean
+ */
+function getFailBuild(): boolean {
+  return core.getInput("fail-build").toLowerCase() === "true";
 }
 
 export function getRepositoryName(): string {


### PR DESCRIPTION
Run this action as part of a build workflow.  When input `fail-build: true`, fail the action if EOL check does not pass.

Remove requirement for setting alert webhooks so that the action can be used in a build step that be configured to fail the build.

If EOL check fails, a GHA notice is printed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added an optional input parameter to fail the build when an end-of-life (EOL) version is detected.
- **Documentation**
	- Updated usage instructions, examples, and input descriptions to include the new parameter and clarify supported languages and alert channels.
- **Bug Fixes**
	- Enhanced error logging for unknown errors.
- **Tests**
	- Expanded test coverage to verify build failure behavior with the new input enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->